### PR TITLE
List tables for Verizon Thingspace IoT archive change

### DIFF
--- a/VerizonThingspaceIoT_AllChangeTypes_Tables.md
+++ b/VerizonThingspaceIoT_AllChangeTypes_Tables.md
@@ -1,0 +1,94 @@
+# Verizon ThingSpace IoT - All Change Types Tables
+
+## 1. Assign Customer Change Type
+
+| Table Name                 | Purpose                                                | Key Fields                                                                                                                                                                |
+| -------------------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **DeviceBulkChange**       | Main bulk change tracking and management table         | `Id` (PK), `TenantId`, `Status`, `ChangeRequestTypeId`, `ChangeRequestType`, `ServiceProviderId`, `ServiceProvider`, `IntegrationId`, `Integration`, `PortalTypeId`, `CreatedBy`, `ProcessedDate` |
+| **M2M_DeviceChange**       | Individual device change tracking for M2M devices      | `Id` (PK), `BulkChangeId` (FK), `DeviceId`, `ICCID`, `MSISDN`, `Status`, `ChangeRequest`, `IsProcessed`, `ProcessedDate`, `IsActive`, `IsDeleted`                       |
+| **Mobility_DeviceChange**  | Individual device change tracking for Mobility devices | `Id` (PK), `BulkChangeId` (FK), `ICCID`, `Status`, `ChangeRequest`, `StatusDetails`, `IsProcessed`, `ProcessedDate`, `IsActive`, `IsDeleted`                          |
+| **Device**                 | Main device information and status table               | `Id` (PK), `ICCID`, `IMEI`, `MSISDN`, `DeviceStatusId`, `ServiceProviderId`, `TenantId`, `IsActive`, `IsDeleted`, `ModifiedBy`, `ModifiedDate`, `IpAddress`             |
+| **Device_Tenant**          | Device to tenant/customer assignment mapping           | `Id` (PK), `DeviceId` (FK), `TenantId`, `SiteId`, `AssignedDate`, `UnassignedDate`, `IsActive`, `CreatedBy`, `CreatedDate`                                             |
+| **Site**                   | Customer site/location information                     | `Id` (PK), `TenantId`, `SiteName`, `Address`, `City`, `State`, `ZipCode`, `IsActive`, `IsDeleted`, `CreatedBy`, `CreatedDate`                                          |
+| **RevCustomer**            | Rev customer information for integration               | `Id` (PK), `RevCustomerId`, `CustomerName`, `TenantId`, `IntegrationAuthenticationId`, `IsActive`, `CreatedBy`, `CreatedDate`                                         |
+| **RevServiceDetail**       | Rev service details and configuration                  | `Id` (PK), `RevServiceId`, `ICCID`, `MSISDN`, `TenantId`, `ActivatedDate`, `IntegrationAuthenticationId`, `ServiceStatus`                                             |
+| **M2M_DeviceBulkChangeLog** | Comprehensive logging for M2M device operations       | `Id` (PK), `BulkChangeId`, `M2MDeviceChangeId`, `LogEntryDescription`, `RequestText`, `ResponseText`, `ResponseStatus`, `HasErrors`, `ErrorText`, `ProcessBy`, `ProcessedDate` |
+
+## 2. Carrier Rate Plan Change Type
+
+| Table Name                 | Purpose                                                | Key Fields                                                                                                                                                                |
+| -------------------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **DeviceBulkChange**       | Main bulk change tracking and management table         | `Id` (PK), `TenantId`, `Status`, `ChangeRequestTypeId`, `ChangeRequestType`, `ServiceProviderId`, `ServiceProvider`, `IntegrationId`, `Integration`, `PortalTypeId`, `CreatedBy`, `ProcessedDate` |
+| **M2M_DeviceChange**       | Individual device change tracking for M2M devices      | `Id` (PK), `BulkChangeId` (FK), `DeviceId`, `ICCID`, `MSISDN`, `Status`, `ChangeRequest`, `IsProcessed`, `ProcessedDate`, `IsActive`, `IsDeleted`                       |
+| **Mobility_DeviceChange**  | Individual device change tracking for Mobility devices | `Id` (PK), `BulkChangeId` (FK), `ICCID`, `Status`, `ChangeRequest`, `StatusDetails`, `IsProcessed`, `ProcessedDate`, `IsActive`, `IsDeleted`                          |
+| **Device**                 | Main device information and status table               | `Id` (PK), `ICCID`, `IMEI`, `MSISDN`, `DeviceStatusId`, `ServiceProviderId`, `TenantId`, `CarrierRatePlanId`, `RatePlan`, `IsActive`, `IsDeleted`, `ModifiedBy`, `ModifiedDate` |
+| **JasperCarrierRatePlan**  | Jasper carrier rate plan definitions                   | `Id` (PK), `ServiceProviderId`, `RatePlanCode`, `RatePlanName`, `Description`, `IsActive`, `IsDeleted`, `CreatedBy`, `CreatedDate`                                     |
+| **TelegenceCarrierRatePlan** | Telegence carrier rate plan definitions             | `Id` (PK), `ServiceProviderId`, `CarrierRatePlan`, `Description`, `EffectiveDate`, `IsActive`, `IsDeleted`, `CreatedBy`, `CreatedDate`                                |
+| **ThingSpaceCarrierRatePlan** | ThingSpace carrier rate plan definitions            | `Id` (PK), `ServiceProviderId`, `RatePlanCode`, `RatePlanName`, `PlanUuid`, `IsActive`, `IsDeleted`, `CreatedBy`, `CreatedDate`                                        |
+| **PondDeviceCarrierRatePlan** | Pond carrier rate plan tracking                     | `Id` (PK), `DeviceId`, `PackageId`, `PackageTypeId`, `Status`, `ServiceProviderId`, `CreatedBy`, `CreatedDate`, `IsActive`                                            |
+| **M2M_DeviceBulkChangeLog** | Comprehensive logging for M2M device operations       | `Id` (PK), `BulkChangeId`, `M2MDeviceChangeId`, `LogEntryDescription`, `RequestText`, `ResponseText`, `ResponseStatus`, `HasErrors`, `ErrorText`, `ProcessBy`, `ProcessedDate` |
+
+## 3. Customer Rate Plan Change Type
+
+| Table Name                 | Purpose                                                | Key Fields                                                                                                                                                                |
+| -------------------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **DeviceBulkChange**       | Main bulk change tracking and management table         | `Id` (PK), `TenantId`, `Status`, `ChangeRequestTypeId`, `ChangeRequestType`, `ServiceProviderId`, `ServiceProvider`, `IntegrationId`, `Integration`, `PortalTypeId`, `CreatedBy`, `ProcessedDate` |
+| **M2M_DeviceChange**       | Individual device change tracking for M2M devices      | `Id` (PK), `BulkChangeId` (FK), `DeviceId`, `ICCID`, `MSISDN`, `Status`, `ChangeRequest`, `IsProcessed`, `ProcessedDate`, `IsActive`, `IsDeleted`                       |
+| **Mobility_DeviceChange**  | Individual device change tracking for Mobility devices | `Id` (PK), `BulkChangeId` (FK), `ICCID`, `Status`, `ChangeRequest`, `StatusDetails`, `IsProcessed`, `ProcessedDate`, `IsActive`, `IsDeleted`                          |
+| **Device**                 | Main device information and status table               | `Id` (PK), `ICCID`, `IMEI`, `MSISDN`, `DeviceStatusId`, `ServiceProviderId`, `TenantId`, `CustomerRatePlanId`, `CustomerRatePoolId`, `IsActive`, `IsDeleted`, `ModifiedBy`, `ModifiedDate` |
+| **CustomerRatePlan**       | Customer rate plan definitions and configuration       | `Id` (PK), `TenantId`, `ServiceProviderId`, `PlanName`, `Description`, `MonthlyRate`, `DataAllocation`, `IsActive`, `IsDeleted`, `CreatedBy`, `CreatedDate`           |
+| **CustomerRatePool**       | Customer rate pool definitions                         | `Id` (PK), `TenantId`, `ServiceProviderId`, `PoolName`, `Description`, `TotalDataAllocation`, `IsActive`, `IsDeleted`, `CreatedBy`, `CreatedDate`                     |
+| **Device_CustomerRatePlanOrRatePool_Queue** | Queue table for customer rate plan changes | `Id` (PK), `BulkChangeId`, `DeviceId`, `CustomerRatePlanId`, `CustomerRatePoolId`, `EffectiveDate`, `Status`, `CreatedDate`, `ProcessedDate`                          |
+| **DeviceCustomerRatePlan** | Device to customer rate plan assignment history       | `Id` (PK), `DeviceId`, `CustomerRatePlanId`, `EffectiveDate`, `EndDate`, `IsActive`, `CreatedBy`, `CreatedDate`                                                       |
+| **M2M_DeviceBulkChangeLog** | Comprehensive logging for M2M device operations       | `Id` (PK), `BulkChangeId`, `M2MDeviceChangeId`, `LogEntryDescription`, `RequestText`, `ResponseText`, `ResponseStatus`, `HasErrors`, `ErrorText`, `ProcessBy`, `ProcessedDate` |
+| **Mobility_DeviceBulkChangeLog** | Comprehensive logging for Mobility device operations | `Id` (PK), `BulkChangeId`, `MobilityDeviceChangeId`, `LogEntryDescription`, `RequestText`, `ResponseText`, `ResponseStatus`, `HasErrors`, `ErrorText`, `ProcessBy`, `ProcessedDate` |
+
+## 4. ICCID/IMEI Change Type
+
+| Table Name                 | Purpose                                                | Key Fields                                                                                                                                                                |
+| -------------------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **DeviceBulkChange**       | Main bulk change tracking and management table         | `Id` (PK), `TenantId`, `Status`, `ChangeRequestTypeId`, `ChangeRequestType`, `ServiceProviderId`, `ServiceProvider`, `IntegrationId`, `Integration`, `PortalTypeId`, `CreatedBy`, `ProcessedDate` |
+| **M2M_DeviceChange**       | Individual device change tracking for M2M devices      | `Id` (PK), `BulkChangeId` (FK), `DeviceId`, `ICCID`, `MSISDN`, `Status`, `ChangeRequest`, `IsProcessed`, `ProcessedDate`, `IsActive`, `IsDeleted`                       |
+| **Mobility_DeviceChange**  | Individual device change tracking for Mobility devices | `Id` (PK), `BulkChangeId` (FK), `ICCID`, `Status`, `ChangeRequest`, `StatusDetails`, `IsProcessed`, `ProcessedDate`, `IsActive`, `IsDeleted`                          |
+| **Device**                 | Main device information and status table               | `Id` (PK), `ICCID`, `IMEI`, `MSISDN`, `DeviceStatusId`, `ServiceProviderId`, `TenantId`, `IsActive`, `IsDeleted`, `ModifiedBy`, `ModifiedDate`                          |
+| **DeviceIdentifierChangeHistory** | History of ICCID/IMEI changes for audit trail      | `Id` (PK), `DeviceId`, `OldICCID`, `NewICCID`, `OldIMEI`, `NewIMEI`, `ChangeReason`, `ChangedBy`, `ChangeDate`, `BulkChangeId`                                         |
+| **TelegenceDevice**        | Telegence-specific device information                  | `Id` (PK), `SubscriberNumber`, `ICCID`, `IMEI`, `ServiceProviderId`, `BillingAccountNumber`, `FoundationAccountNumber`, `IsActive`, `IsDeleted`                       |
+| **ThingSpaceCallBackResponseLog** | ThingSpace API callback response tracking         | `Id` (PK), `RequestId`, `ICCID`, `APIStatus`, `APIResponse`, `CallbackDate`, `ProcessedDate`, `BulkChangeId`                                                           |
+| **JasperDevice**           | Jasper-specific device tracking                       | `Id` (PK), `ICCID`, `IMEI`, `JasperDeviceId`, `ServiceProviderId`, `Status`, `LastCommunication`, `IsActive`, `IsDeleted`                                             |
+| **M2M_DeviceBulkChangeLog** | Comprehensive logging for M2M device operations       | `Id` (PK), `BulkChangeId`, `M2MDeviceChangeId`, `LogEntryDescription`, `RequestText`, `ResponseText`, `ResponseStatus`, `HasErrors`, `ErrorText`, `ProcessBy`, `ProcessedDate` |
+| **Mobility_DeviceBulkChangeLog** | Comprehensive logging for Mobility device operations | `Id` (PK), `BulkChangeId`, `MobilityDeviceChangeId`, `LogEntryDescription`, `RequestText`, `ResponseText`, `ResponseStatus`, `HasErrors`, `ErrorText`, `ProcessBy`, `ProcessedDate` |
+
+## 5. Update Device Status Change Type
+
+| Table Name                 | Purpose                                                | Key Fields                                                                                                                                                                |
+| -------------------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **DeviceBulkChange**       | Main bulk change tracking and management table         | `Id` (PK), `TenantId`, `Status`, `ChangeRequestTypeId`, `ChangeRequestType`, `ServiceProviderId`, `ServiceProvider`, `IntegrationId`, `Integration`, `PortalTypeId`, `CreatedBy`, `ProcessedDate` |
+| **M2M_DeviceChange**       | Individual device change tracking for M2M devices      | `Id` (PK), `BulkChangeId` (FK), `DeviceId`, `ICCID`, `MSISDN`, `Status`, `ChangeRequest`, `IsProcessed`, `ProcessedDate`, `IsActive`, `IsDeleted`                       |
+| **Mobility_DeviceChange**  | Individual device change tracking for Mobility devices | `Id` (PK), `BulkChangeId` (FK), `ICCID`, `Status`, `ChangeRequest`, `StatusDetails`, `IsProcessed`, `ProcessedDate`, `IsActive`, `IsDeleted`                          |
+| **Device**                 | Main device information and status table               | `Id` (PK), `ICCID`, `IMEI`, `MSISDN`, `DeviceStatusId`, `ServiceProviderId`, `TenantId`, `Status`, `IsActive`, `IsDeleted`, `ModifiedBy`, `ModifiedDate`               |
+| **DeviceStatus**           | Device status definitions and configurations           | `Id` (PK), `StatusName`, `DisplayName`, `Description`, `IntegrationId`, `AllowsApiUpdate`, `IsActive`, `IsDeleted`, `CreatedBy`, `CreatedDate`                        |
+| **DeviceStatusHistory**    | Historical tracking of device status changes          | `Id` (PK), `DeviceId`, `OldStatus`, `NewStatus`, `StatusReason`, `ChangeDate`, `ChangedBy`, `BulkChangeId`, `Comments`                                                |
+| **ThingSpaceDeviceStatusReasonCodes** | ThingSpace status reason code mappings       | `Id` (PK), `StatusId`, `ReasonCode`, `ReasonDescription`, `IntegrationId`, `IsActive`, `CreatedBy`, `CreatedDate`                                                     |
+| **JasperDeviceStatus**     | Jasper-specific device status tracking                | `Id` (PK), `ICCID`, `DeviceId`, `Status`, `StatusDate`, `ReasonCode`, `ServiceProviderId`, `LastUpdated`                                                              |
+| **TelegenceDeviceStatus**  | Telegence-specific device status information          | `Id` (PK), `SubscriberNumber`, `ICCID`, `Status`, `StatusReason`, `EffectiveDate`, `ServiceProviderId`, `LastUpdated`                                                |
+| **RevServiceDetail**       | Rev service status and configuration details          | `Id` (PK), `RevServiceId`, `ICCID`, `MSISDN`, `TenantId`, `ServiceStatus`, `ActivatedDate`, `DeactivatedDate`, `IntegrationAuthenticationId`                        |
+| **M2M_DeviceBulkChangeLog** | Comprehensive logging for M2M device operations       | `Id` (PK), `BulkChangeId`, `M2MDeviceChangeId`, `LogEntryDescription`, `RequestText`, `ResponseText`, `ResponseStatus`, `HasErrors`, `ErrorText`, `ProcessBy`, `ProcessedDate` |
+| **Mobility_DeviceBulkChangeLog** | Comprehensive logging for Mobility device operations | `Id` (PK), `BulkChangeId`, `MobilityDeviceChangeId`, `LogEntryDescription`, `RequestText`, `ResponseText`, `ResponseStatus`, `HasErrors`, `ErrorText`, `ProcessBy`, `ProcessedDate` |
+
+---
+
+## Summary Table Count by Change Type
+
+| Change Type               | Primary Tables | Supporting Tables | Log Tables | Total Tables |
+| ------------------------- | -------------- | ----------------- | ---------- | ------------ |
+| Assign Customer           | 4              | 4                 | 1          | 9            |
+| Carrier Rate Plan Change  | 4              | 4                 | 1          | 9            |
+| Customer Rate Plan Change | 4              | 5                 | 2          | 11           |
+| ICCID/IMEI Change         | 4              | 5                 | 2          | 11           |
+| Update Device Status      | 4              | 7                 | 2          | 13           |
+
+**Total Unique Tables**: 35+ (with some overlap between change types)
+
+---
+
+*This documentation provides a comprehensive view of all tables involved in the five major change types for Verizon ThingSpace IoT Service Provider operations.*

--- a/VerizonThingspaceIoT_ArchiveChangeTables.md
+++ b/VerizonThingspaceIoT_ArchiveChangeTables.md
@@ -1,0 +1,232 @@
+# Verizon Thingspace IoT - Archive Change Type Tables
+
+## Overview
+This document provides a comprehensive list of all database tables involved in Archive Change Type bulk operations within the Verizon Thingspace IoT platform.
+
+## Table Categories
+
+### 1. Primary Bulk Change Tables
+
+#### DeviceBulkChange
+**Purpose**: Main bulk change tracking and management table
+- **Description**: Stores bulk change requests with their status, metadata, and processing information
+- **Key Fields**:
+  - `Id` (Primary Key) - Unique bulk change identifier
+  - `TenantId` - Tenant/customer identifier
+  - `Status` - Current status of the bulk change operation
+  - `ChangeRequestTypeId` - Type of change request (Archive = specific ID)
+  - `ChangeRequestType` - Human-readable change type description
+  - `ServiceProviderId` - Service provider identifier
+  - `ServiceProvider` - Service provider name
+  - `IntegrationId` - Integration type identifier
+  - `Integration` - Integration type name
+  - `PortalTypeId` - Portal type (M2M, Mobility, LNP)
+  - `CreatedBy` - User who initiated the bulk change
+  - `ProcessedDate` - When the operation was completed
+
+#### M2M_DeviceChange
+**Purpose**: Individual device change tracking for M2M (Machine-to-Machine) devices
+- **Description**: Stores individual device changes within a bulk archive operation for M2M devices
+- **Key Fields**:
+  - `Id` (Primary Key) - Unique device change identifier
+  - `BulkChangeId` (Foreign Key) - References DeviceBulkChange.Id
+  - `DeviceId` - Reference to the device being archived
+  - `ICCID` - SIM card identifier
+  - `MSISDN` - Mobile phone number
+  - `Status` - Current status of the device change
+  - `ChangeRequest` - JSON containing change details
+  - `IsProcessed` - Boolean indicating if change is complete
+  - `ProcessedDate` - When the device change was processed
+  - `IsActive` - Boolean indicating if record is active
+  - `IsDeleted` - Boolean indicating if record is deleted
+
+#### Mobility_DeviceChange
+**Purpose**: Individual device change tracking for Mobility devices
+- **Description**: Stores individual device changes within a bulk archive operation for mobility/cellular devices
+- **Key Fields**:
+  - `Id` (Primary Key) - Unique device change identifier
+  - `BulkChangeId` (Foreign Key) - References DeviceBulkChange.Id
+  - `ICCID` - SIM card identifier
+  - `Status` - Current status of the device change
+  - `ChangeRequest` - JSON containing change details
+  - `StatusDetails` - Additional status information
+  - `IsProcessed` - Boolean indicating if change is complete
+  - `ProcessedDate` - When the device change was processed
+  - `IsActive` - Boolean indicating if record is active
+  - `IsDeleted` - Boolean indicating if record is deleted
+
+#### LNP_DeviceChange
+**Purpose**: Individual device change tracking for LNP (Local Number Portability) devices
+- **Description**: Stores individual device changes within a bulk archive operation for LNP devices
+- **Key Fields**: Similar structure to other DeviceChange tables but specific to LNP operations
+
+### 2. Core Device Tables
+
+#### Device
+**Purpose**: Main device information and status table
+- **Description**: Central repository for all device information, updated during archive operations
+- **Key Fields**:
+  - `Id` (Primary Key) - Unique device identifier
+  - `ICCID` - SIM card identifier
+  - `IMEI` - Device identifier
+  - `MSISDN` - Mobile phone number
+  - `DeviceStatusId` - Current device status
+  - `ServiceProviderId` - Service provider identifier
+  - `TenantId` - Tenant/customer identifier
+  - `IsActive` - Boolean indicating if device is active (set to 0 during archive)
+  - `IsDeleted` - Boolean indicating if device is deleted (set to 1 during archive)
+  - `ModifiedBy` - User/system that last modified the record
+  - `ModifiedDate` - Last modification timestamp
+  - `IpAddress` - Device IP address (if applicable)
+
+### 3. Audit and Logging Tables
+
+#### M2M_DeviceBulkChangeLog
+**Purpose**: Comprehensive logging for M2M device bulk change operations
+- **Description**: Tracks all operations, results, and errors for M2M device archive operations
+- **Key Fields**:
+  - `Id` (Primary Key) - Unique log entry identifier
+  - `BulkChangeId` - Reference to bulk change operation
+  - `M2MDeviceChangeId` - Reference to specific device change
+  - `LogEntryDescription` - Description of the operation
+  - `RequestText` - Details of the request made
+  - `ResponseText` - Response received from the operation
+  - `ResponseStatus` - Status of the operation (PROCESSED, ERROR, etc.)
+  - `HasErrors` - Boolean indicating if errors occurred
+  - `ErrorText` - Error details if applicable
+  - `ProcessBy` - System/user that processed the operation
+  - `ProcessedDate` - When the operation was logged
+
+#### Mobility_DeviceBulkChangeLog
+**Purpose**: Comprehensive logging for Mobility device bulk change operations
+- **Description**: Tracks all operations, results, and errors for Mobility device archive operations
+- **Key Fields**:
+  - `Id` (Primary Key) - Unique log entry identifier
+  - `BulkChangeId` - Reference to bulk change operation
+  - `MobilityDeviceChangeId` - Reference to specific device change
+  - `LogEntryDescription` - Description of the operation
+  - `RequestText` - Details of the request made
+  - `ResponseText` - Response received from the operation
+  - `ResponseStatus` - Status of the operation (PROCESSED, ERROR, etc.)
+  - `HasErrors` - Boolean indicating if errors occurred
+  - `ErrorText` - Error details if applicable
+  - `ProcessBy` - System/user that processed the operation
+  - `ProcessedDate` - When the operation was logged
+
+#### LNP_DeviceBulkChangeLog
+**Purpose**: Comprehensive logging for LNP device bulk change operations
+- **Description**: Tracks all operations, results, and errors for LNP device archive operations
+- **Key Fields**: Similar structure to other logging tables but specific to LNP operations
+
+### 4. Supporting Tables
+
+#### TelegenceDevice
+**Purpose**: Telegence-specific device information
+- **Description**: Contains additional device information for Telegence integration
+- **Key Fields**:
+  - `Id` (Primary Key) - Unique device identifier
+  - `SubscriberNumber` - Subscriber phone number
+  - `ICCID` - SIM card identifier
+  - `ServiceProviderId` - Service provider identifier
+  - `BillingAccountNumber` - Billing account reference
+  - `FoundationAccountNumber` - Foundation account reference
+  - `IsActive` - Boolean indicating if device is active
+  - `IsDeleted` - Boolean indicating if device is deleted
+
+## Key Stored Procedures
+
+### usp_DeviceBulkChange_Archival_ArchiveDevices
+**Purpose**: Main stored procedure for executing archive operations
+- **Parameters**:
+  - `@bulkChangeId` - The bulk change operation identifier
+  - `@changeIds` - Comma-separated list of device change IDs to process
+- **Functionality**:
+  - Updates device status to archived/inactive
+  - Marks devices as deleted in the system
+  - Updates bulk change status to processed
+  - Handles error conditions and rollback scenarios
+
+## Archive Operation Flow
+
+### 1. Initiation Phase
+- Record created in `DeviceBulkChange` table with Archive change type
+- Individual device records created in appropriate `*_DeviceChange` table based on portal type
+
+### 2. Processing Phase
+- `usp_DeviceBulkChange_Archival_ArchiveDevices` stored procedure executed
+- Device status updated in `Device` table:
+  - `IsActive` set to `0`
+  - `IsDeleted` set to `1`
+  - `DeviceStatusId` updated to archived status
+
+### 3. Completion Phase
+- Bulk change status updated to `PROCESSED`
+- Individual device change records marked as processed
+- Comprehensive logging entries created in appropriate log tables
+
+### 4. Validation Checks
+- Recent usage validation (devices with usage in last X days cannot be archived)
+- Device eligibility verification
+- Duplicate archive prevention
+
+## Portal Type Differentiation
+
+| Portal Type | Device Change Table | Log Table | Description |
+|-------------|-------------------|-----------|-------------|
+| M2M | M2M_DeviceChange | M2M_DeviceBulkChangeLog | Machine-to-Machine devices |
+| Mobility | Mobility_DeviceChange | Mobility_DeviceBulkChangeLog | Cellular/mobile devices |
+| LNP | LNP_DeviceChange | LNP_DeviceBulkChangeLog | Local Number Portability devices |
+
+## Status Values
+
+### Bulk Change Status
+- `PROCESSING` - Operation in progress
+- `PROCESSED` - Operation completed successfully
+- `ERROR` - Operation failed with errors
+
+### Device Change Status
+- `PENDING` - Awaiting processing
+- `PROCESSING` - Currently being processed
+- `PROCESSED` - Successfully completed
+- `ERROR` - Failed with errors
+- `API_FAILED` - API call failed
+
+## Integration Types
+
+The system supports multiple integration types for different carriers:
+- **Telegence** - Primary integration for Verizon services
+- **ThingSpace** - Verizon's IoT platform integration
+- **Jasper** - Legacy Cisco Jasper integration
+- **Teal** - Alternative carrier integration
+
+## Best Practices
+
+### Archive Operation Guidelines
+1. **Validation**: Always validate device eligibility before archiving
+2. **Batch Size**: Process archives in manageable batches to avoid timeouts
+3. **Error Handling**: Implement comprehensive error handling and logging
+4. **Rollback**: Ensure rollback capabilities for failed operations
+5. **Audit Trail**: Maintain complete audit trails for compliance
+
+### Performance Considerations
+- Use appropriate indexing on ICCID and BulkChangeId fields
+- Implement proper connection pooling for database operations
+- Consider asynchronous processing for large batch operations
+- Monitor log table growth and implement archiving strategies
+
+## Troubleshooting
+
+### Common Issues
+1. **Device Already Archived**: Check `IsActive` and `IsDeleted` status in Device table
+2. **Recent Usage Conflicts**: Verify usage validation rules and timeframes
+3. **Permission Issues**: Ensure proper tenant and service provider access
+4. **API Timeouts**: Review batch sizes and implement retry mechanisms
+
+### Log Analysis
+- Check appropriate `*_DeviceBulkChangeLog` table for detailed operation history
+- Review `ErrorText` field for specific error conditions
+- Analyze `ResponseStatus` patterns for systemic issues
+
+---
+
+*This documentation is based on the Verizon Thingspace IoT platform codebase analysis and reflects the current table structure for Archive Change Type operations.*

--- a/VerizonThingspaceIoT_ArchiveChangeTables_Tabular.md
+++ b/VerizonThingspaceIoT_ArchiveChangeTables_Tabular.md
@@ -1,0 +1,125 @@
+# Verizon Thingspace IoT - Archive Change Type Tables (Tabular Format)
+
+## Primary Bulk Change Tables
+
+| Table Name | Purpose | Key Fields |
+|------------|---------|------------|
+| **DeviceBulkChange** | Main bulk change tracking and management table | `Id` (PK), `TenantId`, `Status`, `ChangeRequestTypeId`, `ChangeRequestType`, `ServiceProviderId`, `ServiceProvider`, `IntegrationId`, `Integration`, `PortalTypeId`, `CreatedBy`, `ProcessedDate` |
+| **M2M_DeviceChange** | Individual device change tracking for M2M devices | `Id` (PK), `BulkChangeId` (FK), `DeviceId`, `ICCID`, `MSISDN`, `Status`, `ChangeRequest`, `IsProcessed`, `ProcessedDate`, `IsActive`, `IsDeleted` |
+| **Mobility_DeviceChange** | Individual device change tracking for Mobility devices | `Id` (PK), `BulkChangeId` (FK), `ICCID`, `Status`, `ChangeRequest`, `StatusDetails`, `IsProcessed`, `ProcessedDate`, `IsActive`, `IsDeleted` |
+| **LNP_DeviceChange** | Individual device change tracking for LNP devices | `Id` (PK), `BulkChangeId` (FK), `ICCID`, `Status`, `ChangeRequest`, `IsProcessed`, `ProcessedDate`, `IsActive`, `IsDeleted` |
+
+## Core Device Tables
+
+| Table Name | Purpose | Key Fields |
+|------------|---------|------------|
+| **Device** | Main device information and status table | `Id` (PK), `ICCID`, `IMEI`, `MSISDN`, `DeviceStatusId`, `ServiceProviderId`, `TenantId`, `IsActive`, `IsDeleted`, `ModifiedBy`, `ModifiedDate`, `IpAddress` |
+| **TelegenceDevice** | Telegence-specific device information | `Id` (PK), `SubscriberNumber`, `ICCID`, `ServiceProviderId`, `BillingAccountNumber`, `FoundationAccountNumber`, `IsActive`, `IsDeleted` |
+
+## Audit and Logging Tables
+
+| Table Name | Purpose | Key Fields |
+|------------|---------|------------|
+| **M2M_DeviceBulkChangeLog** | Comprehensive logging for M2M device operations | `Id` (PK), `BulkChangeId`, `M2MDeviceChangeId`, `LogEntryDescription`, `RequestText`, `ResponseText`, `ResponseStatus`, `HasErrors`, `ErrorText`, `ProcessBy`, `ProcessedDate` |
+| **Mobility_DeviceBulkChangeLog** | Comprehensive logging for Mobility device operations | `Id` (PK), `BulkChangeId`, `MobilityDeviceChangeId`, `LogEntryDescription`, `RequestText`, `ResponseText`, `ResponseStatus`, `HasErrors`, `ErrorText`, `ProcessBy`, `ProcessedDate` |
+| **LNP_DeviceBulkChangeLog** | Comprehensive logging for LNP device operations | `Id` (PK), `BulkChangeId`, `LNPDeviceChangeId`, `LogEntryDescription`, `RequestText`, `ResponseText`, `ResponseStatus`, `HasErrors`, `ErrorText`, `ProcessBy`, `ProcessedDate` |
+
+## Field Details by Category
+
+### Primary Keys and Foreign Keys
+
+| Table | Primary Key | Foreign Keys | Relationships |
+|-------|-------------|--------------|---------------|
+| DeviceBulkChange | `Id` | None | Parent to all DeviceChange tables |
+| M2M_DeviceChange | `Id` | `BulkChangeId` → DeviceBulkChange.Id | Child of DeviceBulkChange |
+| Mobility_DeviceChange | `Id` | `BulkChangeId` → DeviceBulkChange.Id | Child of DeviceBulkChange |
+| LNP_DeviceChange | `Id` | `BulkChangeId` → DeviceBulkChange.Id | Child of DeviceBulkChange |
+| Device | `Id` | None | Referenced by DeviceChange tables |
+| TelegenceDevice | `Id` | None | Supporting device information |
+
+### Status and Control Fields
+
+| Field Name | Tables | Data Type | Purpose | Possible Values |
+|------------|--------|-----------|---------|-----------------|
+| `Status` | DeviceBulkChange, *_DeviceChange | VARCHAR | Operation status tracking | PROCESSING, PROCESSED, ERROR |
+| `IsActive` | *_DeviceChange, Device, TelegenceDevice | BIT | Record active status | 0 (Inactive), 1 (Active) |
+| `IsDeleted` | *_DeviceChange, Device, TelegenceDevice | BIT | Record deletion status | 0 (Not Deleted), 1 (Deleted) |
+| `IsProcessed` | *_DeviceChange | BIT | Processing completion status | 0 (Not Processed), 1 (Processed) |
+| `HasErrors` | *_DeviceBulkChangeLog | BIT | Error occurrence indicator | 0 (No Errors), 1 (Has Errors) |
+
+### Identifier Fields
+
+| Field Name | Tables | Data Type | Purpose | Description |
+|------------|--------|-----------|---------|-------------|
+| `ICCID` | Device, *_DeviceChange, TelegenceDevice | VARCHAR | SIM card identifier | Integrated Circuit Card Identifier |
+| `IMEI` | Device | VARCHAR | Device identifier | International Mobile Equipment Identity |
+| `MSISDN` | Device, M2M_DeviceChange | VARCHAR | Mobile phone number | Mobile Station International Subscriber Directory Number |
+| `SubscriberNumber` | TelegenceDevice | VARCHAR | Subscriber phone number | Telegence-specific subscriber identifier |
+| `TenantId` | DeviceBulkChange, Device | INT | Customer/tenant identifier | Multi-tenant system identifier |
+| `ServiceProviderId` | DeviceBulkChange, Device, TelegenceDevice | INT | Service provider identifier | Carrier/provider reference |
+
+### Timestamp Fields
+
+| Field Name | Tables | Data Type | Purpose |
+|------------|--------|-----------|---------|
+| `ProcessedDate` | DeviceBulkChange, *_DeviceChange, *_DeviceBulkChangeLog | DATETIME | When operation was completed |
+| `ModifiedDate` | Device | DATETIME | Last modification timestamp |
+
+### Configuration Fields
+
+| Field Name | Tables | Data Type | Purpose | Description |
+|------------|--------|-----------|---------|-------------|
+| `ChangeRequestTypeId` | DeviceBulkChange | INT | Type of change operation | Numeric identifier for Archive type |
+| `ChangeRequestType` | DeviceBulkChange | VARCHAR | Human-readable change type | "Archival" for archive operations |
+| `PortalTypeId` | DeviceBulkChange | INT | Portal type identifier | 1=M2M, 2=Mobility, 3=LNP |
+| `IntegrationId` | DeviceBulkChange | INT | Integration type identifier | 1=Telegence, 2=ThingSpace, etc. |
+| `DeviceStatusId` | Device | INT | Current device status | Status code for device state |
+
+### JSON and Large Text Fields
+
+| Field Name | Tables | Data Type | Purpose | Content Example |
+|------------|--------|-----------|---------|-----------------|
+| `ChangeRequest` | *_DeviceChange | NVARCHAR(MAX) | JSON change details | `{"archiveReason": "end-of-life"}` |
+| `StatusDetails` | Mobility_DeviceChange | NVARCHAR(MAX) | Additional status info | Processing details and results |
+| `RequestText` | *_DeviceBulkChangeLog | NVARCHAR(MAX) | Request details | API call details, parameters |
+| `ResponseText` | *_DeviceBulkChangeLog | NVARCHAR(MAX) | Response details | API response, success/error info |
+| `ErrorText` | *_DeviceBulkChangeLog | NVARCHAR(MAX) | Error information | Detailed error messages |
+
+## Portal Type Mapping
+
+| Portal Type ID | Portal Name | Device Change Table | Log Table | Description |
+|----------------|-------------|-------------------|-----------|-------------|
+| 1 | M2M | M2M_DeviceChange | M2M_DeviceBulkChangeLog | Machine-to-Machine devices |
+| 2 | Mobility | Mobility_DeviceChange | Mobility_DeviceBulkChangeLog | Cellular/mobile devices |
+| 3 | LNP | LNP_DeviceChange | LNP_DeviceBulkChangeLog | Local Number Portability devices |
+
+## Integration Type Mapping
+
+| Integration ID | Integration Name | Description | Supported Operations |
+|----------------|------------------|-------------|---------------------|
+| 1 | Telegence | Primary Verizon integration | Archive, Status Update, Rate Plan Change |
+| 2 | ThingSpace | Verizon IoT platform | Archive, Activation, Monitoring |
+| 3 | Jasper | Legacy Cisco integration | Archive, Status Update |
+| 4 | Teal | Alternative carrier | Archive, Rate Plan Change |
+
+## Archive Operation Table Usage Flow
+
+| Step | Phase | Tables Involved | Operations |
+|------|-------|----------------|------------|
+| 1 | Initiation | DeviceBulkChange | INSERT new bulk change record |
+| 2 | Device Setup | *_DeviceChange (based on portal type) | INSERT individual device change records |
+| 3 | Validation | Device | SELECT to validate device eligibility |
+| 4 | Processing | All tables via stored procedure | UPDATE device status, mark as archived |
+| 5 | Logging | *_DeviceBulkChangeLog | INSERT operation logs and results |
+| 6 | Completion | DeviceBulkChange, *_DeviceChange | UPDATE status to PROCESSED |
+
+## Key Stored Procedure Parameters
+
+| Stored Procedure | Parameter | Data Type | Purpose |
+|------------------|-----------|-----------|---------|
+| usp_DeviceBulkChange_Archival_ArchiveDevices | @bulkChangeId | BIGINT | Bulk change operation identifier |
+| usp_DeviceBulkChange_Archival_ArchiveDevices | @changeIds | VARCHAR(MAX) | Comma-separated device change IDs |
+
+---
+
+*This tabular documentation provides a structured view of all tables involved in Verizon Thingspace IoT Archive Change Type operations.*


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add `VerizonThingspaceIoT_ArchiveChangeTables.md` to document tables for Archive Change Type bulk operations.

---
<a href="https://cursor.com/background-agent?bcId=bc-4f6013ea-27d0-4baf-a700-edf6c4e3c65e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4f6013ea-27d0-4baf-a700-edf6c4e3c65e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>