### PR TITLE
Create AT&T POD19 archive change type data flow diagram

### DIFF
--- a/att_pod19_archive_dataflow.drawio
+++ b/att_pod19_archive_dataflow.drawio
@@ -1,0 +1,264 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mxfile host="app.diagrams.net" modified="2024-01-15T12:00:00.000Z" agent="5.0" etag="dataflow-pod19" version="22.1.16" type="device">
+  <diagram name="AT&T POD19 Archive Data Flow" id="att-pod19-archive-flow">
+    <mxGraphModel dx="1422" dy="794" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1169" pageHeight="827" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+        
+        <!-- Title -->
+        <mxCell id="title" value="AT&T POD19 Archive Change Type - Data Flow Diagram" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=18;fontStyle=1" vertex="1" parent="1">
+          <mxGeometry x="320" y="20" width="529" height="30" as="geometry" />
+        </mxCell>
+        
+        <!-- External Entities -->
+        <mxCell id="user" value="User/Admin" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontStyle=1" vertex="1" parent="1">
+          <mxGeometry x="50" y="100" width="100" height="60" as="geometry" />
+        </mxCell>
+        
+        <mxCell id="amop_db" value="AMOP&#xa;Database" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;fontStyle=1" vertex="1" parent="1">
+          <mxGeometry x="950" y="150" width="100" height="60" as="geometry" />
+        </mxCell>
+        
+        <mxCell id="jasper_api" value="Jasper API&#xa;(POD19)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffe6cc;strokeColor=#d79b00;fontStyle=1" vertex="1" parent="1">
+          <mxGeometry x="950" y="350" width="100" height="60" as="geometry" />
+        </mxCell>
+        
+        <!-- Process Circles -->
+        <mxCell id="m2m_controller" value="M2M Controller&#xa;Archive Request" style="ellipse;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontStyle=1" vertex="1" parent="1">
+          <mxGeometry x="250" y="100" width="120" height="80" as="geometry" />
+        </mxCell>
+        
+        <mxCell id="validation" value="Device Validation&#xa;Process" style="ellipse;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontStyle=1" vertex="1" parent="1">
+          <mxGeometry x="450" y="100" width="120" height="80" as="geometry" />
+        </mxCell>
+        
+        <mxCell id="archive_process" value="Archive Device&#xa;Processing" style="ellipse;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontStyle=1" vertex="1" parent="1">
+          <mxGeometry x="650" y="150" width="120" height="80" as="geometry" />
+        </mxCell>
+        
+        <mxCell id="pod19_process" value="POD19 Integration&#xa;Processing" style="ellipse;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontStyle=1" vertex="1" parent="1">
+          <mxGeometry x="650" y="350" width="120" height="80" as="geometry" />
+        </mxCell>
+        
+        <mxCell id="log_process" value="Logging &amp;&#xa;Audit Process" style="ellipse;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontStyle=1" vertex="1" parent="1">
+          <mxGeometry x="450" y="450" width="120" height="80" as="geometry" />
+        </mxCell>
+        
+        <!-- Data Stores -->
+        <mxCell id="device_store" value="D1" style="shape=partialRectangle;whiteSpace=wrap;html=1;left=0;right=0;fillColor=#fff2cc;strokeColor=#d6b656;fontStyle=1" vertex="1" parent="1">
+          <mxGeometry x="250" y="280" width="40" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="device_store_label" value="Device Records" style="text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;" vertex="1" parent="1">
+          <mxGeometry x="300" y="275" width="90" height="30" as="geometry" />
+        </mxCell>
+        
+        <mxCell id="bulk_change_store" value="D2" style="shape=partialRectangle;whiteSpace=wrap;html=1;left=0;right=0;fillColor=#fff2cc;strokeColor=#d6b656;fontStyle=1" vertex="1" parent="1">
+          <mxGeometry x="250" y="320" width="40" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="bulk_change_store_label" value="Bulk Change Records" style="text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;" vertex="1" parent="1">
+          <mxGeometry x="300" y="315" width="120" height="30" as="geometry" />
+        </mxCell>
+        
+        <mxCell id="log_store" value="D3" style="shape=partialRectangle;whiteSpace=wrap;html=1;left=0;right=0;fillColor=#fff2cc;strokeColor=#d6b656;fontStyle=1" vertex="1" parent="1">
+          <mxGeometry x="250" y="560" width="40" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="log_store_label" value="Log Entries" style="text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;" vertex="1" parent="1">
+          <mxGeometry x="300" y="555" width="80" height="30" as="geometry" />
+        </mxCell>
+        
+        <!-- Data Flows -->
+        <!-- User to M2M Controller -->
+        <mxCell id="flow1" value="" style="endArrow=classic;html=1;rounded=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;" edge="1" parent="1" source="user" target="m2m_controller">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="170" y="140" as="sourcePoint" />
+            <mxPoint x="220" y="90" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="flow1_label" value="Archive Request&#xa;(ICCID List, Tenant ID)" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=10;fontColor=#0066CC;" vertex="1" parent="1">
+          <mxGeometry x="165" y="110" width="90" height="40" as="geometry" />
+        </mxCell>
+        
+        <!-- M2M Controller to Validation -->
+        <mxCell id="flow2" value="" style="endArrow=classic;html=1;rounded=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;" edge="1" parent="1" source="m2m_controller" target="validation">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="380" y="140" as="sourcePoint" />
+            <mxPoint x="430" y="90" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="flow2_label" value="Device Data&#xa;for Validation" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=10;fontColor=#0066CC;" vertex="1" parent="1">
+          <mxGeometry x="385" y="110" width="80" height="40" as="geometry" />
+        </mxCell>
+        
+        <!-- Validation to Archive Process -->
+        <mxCell id="flow3" value="" style="endArrow=classic;html=1;rounded=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;exitX=1;exitY=0.75;exitDx=0;exitDy=0;" edge="1" parent="1" source="validation" target="archive_process">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="580" y="160" as="sourcePoint" />
+            <mxPoint x="630" y="110" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="flow3_label" value="Validated Devices&#xa;for Archival" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=10;fontColor=#0066CC;" vertex="1" parent="1">
+          <mxGeometry x="575" y="145" width="80" height="40" as="geometry" />
+        </mxCell>
+        
+        <!-- Archive Process to POD19 Process -->
+        <mxCell id="flow4" value="" style="endArrow=classic;html=1;rounded=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;exitX=0.5;exitY=1;exitDx=0;exitDy=0;" edge="1" parent="1" source="archive_process" target="pod19_process">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="710" y="240" as="sourcePoint" />
+            <mxPoint x="710" y="340" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="flow4_label" value="POD19 Archive&#xa;Commands" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=10;fontColor=#0066CC;" vertex="1" parent="1">
+          <mxGeometry x="715" y="285" width="80" height="40" as="geometry" />
+        </mxCell>
+        
+        <!-- POD19 Process to Jasper API -->
+        <mxCell id="flow5" value="" style="endArrow=classic;html=1;rounded=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;" edge="1" parent="1" source="pod19_process" target="jasper_api">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="780" y="390" as="sourcePoint" />
+            <mxPoint x="830" y="340" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="flow5_label" value="HTTP/REST&#xa;Archive Requests" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=10;fontColor=#0066CC;" vertex="1" parent="1">
+          <mxGeometry x="825" y="355" width="80" height="40" as="geometry" />
+        </mxCell>
+        
+        <!-- Archive Process to AMOP DB -->
+        <mxCell id="flow6" value="" style="endArrow=classic;html=1;rounded=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;exitX=1;exitY=0.25;exitDx=0;exitDy=0;" edge="1" parent="1" source="archive_process" target="amop_db">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="780" y="170" as="sourcePoint" />
+            <mxPoint x="830" y="120" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="flow6_label" value="SQL/SP&#xa;usp_DeviceBulkChange_&#xa;Archival_ArchiveDevices" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=10;fontColor=#0066CC;" vertex="1" parent="1">
+          <mxGeometry x="810" y="125" width="110" height="60" as="geometry" />
+        </mxCell>
+        
+        <!-- Logging flows -->
+        <mxCell id="flow7" value="" style="endArrow=classic;html=1;rounded=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;exitX=0.25;exitY=1;exitDx=0;exitDy=0;" edge="1" parent="1" source="archive_process" target="log_process">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="680" y="240" as="sourcePoint" />
+            <mxPoint x="510" y="440" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="flow7_label" value="Archive Results&#xa;&amp; Status" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=10;fontColor=#0066CC;" vertex="1" parent="1">
+          <mxGeometry x="565" y="325" width="80" height="40" as="geometry" />
+        </mxCell>
+        
+        <!-- POD19 to Logging -->
+        <mxCell id="flow8" value="" style="endArrow=classic;html=1;rounded=0;entryX=1;entryY=0.25;entryDx=0;entryDy=0;exitX=0;exitY=0.75;exitDx=0;exitDy=0;" edge="1" parent="1" source="pod19_process" target="log_process">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="640" y="400" as="sourcePoint" />
+            <mxPoint x="580" y="470" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="flow8_label" value="POD19 API&#xa;Responses" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=10;fontColor=#0066CC;" vertex="1" parent="1">
+          <mxGeometry x="575" y="415" width="80" height="40" as="geometry" />
+        </mxCell>
+        
+        <!-- Data Store connections -->
+        <mxCell id="flow9" value="" style="endArrow=classic;html=1;rounded=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;exitX=0.25;exitY=1;exitDx=0;exitDy=0;" edge="1" parent="1" source="m2m_controller" target="device_store">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="280" y="190" as="sourcePoint" />
+            <mxPoint x="270" y="270" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="flow9_label" value="Device Lookup" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=10;fontColor=#009900;" vertex="1" parent="1">
+          <mxGeometry x="195" y="225" width="80" height="30" as="geometry" />
+        </mxCell>
+        
+        <mxCell id="flow10" value="" style="endArrow=classic;html=1;rounded=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;exitX=0.5;exitY=1;exitDx=0;exitDy=0;" edge="1" parent="1" source="m2m_controller" target="bulk_change_store">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="310" y="190" as="sourcePoint" />
+            <mxPoint x="270" y="310" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="flow10_label" value="Create Bulk&#xa;Change Record" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=10;fontColor=#009900;" vertex="1" parent="1">
+          <mxGeometry x="315" y="225" width="80" height="40" as="geometry" />
+        </mxCell>
+        
+        <mxCell id="flow11" value="" style="endArrow=classic;html=1;rounded=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;exitX=0.5;exitY=1;exitDx=0;exitDy=0;" edge="1" parent="1" source="log_process" target="log_store">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="510" y="540" as="sourcePoint" />
+            <mxPoint x="270" y="550" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="flow11_label" value="Write Log&#xa;Entries" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=10;fontColor=#009900;" vertex="1" parent="1">
+          <mxGeometry x="355" y="535" width="70" height="30" as="geometry" />
+        </mxCell>
+        
+        <!-- Validation Details -->
+        <mxCell id="validation_details" value="Validation Checks:&#xa;• Device exists&#xa;• No active Rev Services&#xa;• No recent usage (90 days)&#xa;• Not already archived&#xa;• Valid permissions" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#f5f5f5;strokeColor=#666666;fontStyle=0;fontSize=10;align=left;verticalAlign=top;" vertex="1" parent="1">
+          <mxGeometry x="50" y="350" width="160" height="110" as="geometry" />
+        </mxCell>
+        
+        <!-- Processing Details -->
+        <mxCell id="processing_details" value="POD19 Specific:&#xa;• Integration Type: POD19&#xa;• Jasper API Authentication&#xa;• HTTP/REST Protocol&#xa;• Archive Commands&#xa;• Audit Trail Validation" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#f5f5f5;strokeColor=#666666;fontStyle=0;fontSize=10;align=left;verticalAlign=top;" vertex="1" parent="1">
+          <mxGeometry x="50" y="600" width="160" height="110" as="geometry" />
+        </mxCell>
+        
+        <!-- Return Flows -->
+        <mxCell id="return_flow1" value="" style="endArrow=classic;html=1;rounded=0;dashed=1;exitX=0;exitY=0.25;exitDx=0;exitDy=0;entryX=1;entryY=0.75;entryDx=0;entryDy=0;" edge="1" parent="1" source="amop_db" target="archive_process">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="940" y="165" as="sourcePoint" />
+            <mxPoint x="780" y="210" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="return_flow1_label" value="DB Results" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=10;fontColor=#CC6600;" vertex="1" parent="1">
+          <mxGeometry x="825" y="200" width="60" height="20" as="geometry" />
+        </mxCell>
+        
+        <mxCell id="return_flow2" value="" style="endArrow=classic;html=1;rounded=0;dashed=1;exitX=0;exitY=0.75;exitDx=0;exitDy=0;entryX=1;entryY=0.25;entryDx=0;entryDy=0;" edge="1" parent="1" source="jasper_api" target="pod19_process">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="940" y="395" as="sourcePoint" />
+            <mxPoint x="780" y="365" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="return_flow2_label" value="API Results" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=10;fontColor=#CC6600;" vertex="1" parent="1">
+          <mxGeometry x="825" y="395" width="60" height="20" as="geometry" />
+        </mxCell>
+        
+        <!-- Legend -->
+        <mxCell id="legend" value="Legend:" style="text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=12;fontStyle=1" vertex="1" parent="1">
+          <mxGeometry x="50" y="730" width="60" height="20" as="geometry" />
+        </mxCell>
+        
+        <mxCell id="legend_external" value="External Entity" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=10" vertex="1" parent="1">
+          <mxGeometry x="50" y="755" width="80" height="30" as="geometry" />
+        </mxCell>
+        
+        <mxCell id="legend_process" value="Process" style="ellipse;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=10" vertex="1" parent="1">
+          <mxGeometry x="150" y="755" width="60" height="30" as="geometry" />
+        </mxCell>
+        
+        <mxCell id="legend_datastore" value="D#" style="shape=partialRectangle;whiteSpace=wrap;html=1;left=0;right=0;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=10" vertex="1" parent="1">
+          <mxGeometry x="230" y="760" width="20" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="legend_datastore_label" value="Data Store" style="text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=10" vertex="1" parent="1">
+          <mxGeometry x="255" y="755" width="60" height="30" as="geometry" />
+        </mxCell>
+        
+        <mxCell id="legend_flow" value="" style="endArrow=classic;html=1;rounded=0;fontSize=10" edge="1" parent="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="330" y="770" as="sourcePoint" />
+            <mxPoint x="370" y="770" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="legend_flow_label" value="Data Flow" style="text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=10" vertex="1" parent="1">
+          <mxGeometry x="380" y="755" width="60" height="30" as="geometry" />
+        </mxCell>
+        
+        <mxCell id="legend_return" value="" style="endArrow=classic;html=1;rounded=0;dashed=1;fontSize=10" edge="1" parent="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="450" y="770" as="sourcePoint" />
+            <mxPoint x="490" y="770" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="legend_return_label" value="Return Flow" style="text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=10" vertex="1" parent="1">
+          <mxGeometry x="500" y="755" width="70" height="30" as="geometry" />
+        </mxCell>
+        
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>


### PR DESCRIPTION
Add a Draw.io data flow diagram for the AT&T POD19 Archive Change Type process.

---
<a href="https://cursor.com/background-agent?bcId=bc-57a3d8c7-58dd-47a9-9da9-22cb2b4d6a67">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-57a3d8c7-58dd-47a9-9da9-22cb2b4d6a67">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>